### PR TITLE
Set required_ruby_version to 2.4.6

### DIFF
--- a/caa_rr_patch.gemspec
+++ b/caa_rr_patch.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.homepage      = 'https://github.com/thekuwayama/caa_rr_patch'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>=2.6.0'
+  spec.required_ruby_version = '>=2.4.6'
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
I know it's EOL, but I'm using this in a ruby 2.4.6 project and it works just fine.